### PR TITLE
Fixed bind address assignment for Docker mode

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -26,6 +26,9 @@ services:
     depends_on:
       - unoserver
     restart: unless-stopped
+    environment:
+      - DOKEBOSS_API_HOST=0.0.0.0
+
 
 #  dokeboss-dev:
 #  # To run dokeboss-dev do the following:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "dokeboss",
+  "name": "@okesoft/dokeboss",
   "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "dokeboss",
+      "name": "@okesoft/dokeboss",
       "version": "1.0.3",
       "license": "MIT",
       "dependencies": {
@@ -19,6 +19,9 @@
         "fluent-ffmpeg": "^2.1.3",
         "form-data": "^4.0.1",
         "puppeteer": "^23.11.1"
+      },
+      "bin": {
+        "dokeboss-api": "build/api.js"
       },
       "devDependencies": {
         "@babel/preset-typescript": "^7.26.0",


### PR DESCRIPTION
Previously server listened only to localhost, preventing API exposure to host machine/other Docker containers, updated to 0.0.0.0